### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # hello-world
 Finna repo like Snorri Sturluson
+
+"The sun knew not
+Where her hall she had;
+The moon knew not
+What might he had;
+The stars knew not
+Their resting-places."
+
+-- Snorri Sturluson, The Prose Edda, IV.8 "The Creation of the the World" c. 1220
+
+How fragile and flexible our conceptions, but indelible are the essences underlying any beginning. Sometimes most of the journey is the unveiling and reclamation of those essences. 


### PR DESCRIPTION
Added a quote from the The Younger Edda written by historian Snorri Sturluson in the early 13th Century. In ancient Norse, the word for sun was feminine while the word for "moon" was masculine.
